### PR TITLE
implement an on/off switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The prompt layout is:
 (<logo>|<cluster>:<namespace>)
 ```
 
+## Enabling/Disabling
+
+If you want to stop showing Kubernetes status on your prompt string temporarily
+run `kubeoff`. You can enable it again by running `kubeon`.
+
 ## Colors
 
 The colors are of my opinion. Blue was used as the prefix to match the Kubernetes
@@ -80,4 +85,5 @@ the following environment variables:
 
 ## Contributors
 
+* [Ahmet Alp Balkan](https://github/com/ahmetb)
 * Jared Yanovich

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -33,6 +33,7 @@ KUBE_PS1_DIVIDER=":"
 KUBE_PS1_SUFFIX=")"
 KUBE_PS1_UNAME=$(uname)
 KUBE_PS1_LAST_TIME=0
+KUBE_PS1_DISABLE_PATH="$HOME/.kube/kube-ps1/disabled"
 
 if [ "${ZSH_VERSION}" ]; then
   KUBE_PS1_SHELL="zsh"
@@ -145,8 +146,19 @@ _kube_ps1_shell_settings
 # source our symbol
 kube_ps1_label
 
+kubeon() {
+  rm -rf "$KUBE_PS1_DISABLE_PATH"
+}
+
+kubeoff() {
+  mkdir -p "$(dirname $KUBE_PS1_DISABLE_PATH)"
+  touch "$KUBE_PS1_DISABLE_PATH"
+}
+
 # Build our prompt
 kube_ps1() {
+  [ -f "$KUBE_PS1_DISABLE_PATH" ] && return
+
   KUBE_PS1="${reset_color}$KUBE_PS1_PREFIX"
   KUBE_PS1+="${blue}$KUBE_PS1_DEFAULT_LABEL"
   KUBE_PS1+="${reset_color}$KUBE_PS1_SEPERATOR"


### PR DESCRIPTION
Adding kubeon/kubeoff commands to short-circuit the return value
of kube_ps1 function. It uses $HOME/.kube/kube-ps1/disabled file to
save/read the on/off state. Also updated the README to reflect the
changes.

Fixes #7.