### PR TITLE
No default ns

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -27,6 +27,7 @@ KUBE_PS1_SYMBOL_ENABLE="${KUBE_PS1_SYMBOL_ENABLE:-true}"
 KUBE_PS1_SYMBOL_DEFAULT="${KUBE_PS1_SYMBOL_DEFAULT:-\u2388 }"
 KUBE_PS1_SYMBOL_USE_IMG="${KUBE_PS1_SYMBOL_USE_IMG:-false}"
 KUBE_PS1_NS_ENABLE="${KUBE_PS1_NS_ENABLE:-true}"
+KUBE_PS1_NS_DEFAULT_ENABLE="${KUBE_PS1_NS_DEFAULT_ENABLE:-true}"
 KUBE_PS1_PREFIX="${KUBE_PS1_PREFIX-(}"
 KUBE_PS1_SEPARATOR="${KUBE_PS1_SEPARATOR-|}"
 KUBE_PS1_DIVIDER="${KUBE_PS1_DIVIDER-:}"
@@ -243,6 +244,10 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
+    # If default is not desired, unset in that case
+    if [[ "${KUBE_PS1_NS_DEFAULT_ENABLE}" == false && "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
+      KUBE_PS1_NAMESPACE=""
+    fi
   fi
 }
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -244,7 +244,7 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
-    # If default is not desired, unset in that case
+    # If default is not desired, empty string in that case
     if [[ "${KUBE_PS1_NS_DEFAULT_ENABLE}" == false && "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
       KUBE_PS1_NAMESPACE=""
     fi


### PR DESCRIPTION
Hi! I like this prompt a lot but I think the `default` namespace makes it too verbose, specially used in conjunction with `__git_ps1` and other stuff (I have a big prompt!).

With this proposed change, the user can set `KUBE_PS1_NS_DEFAULT_ENABLE=false` if they want to hide that namespace. The namespace separator still shows because I think that's ok anyway, it helps remember that the `default` is the set namespace anyway.

The default value for `KUBE_PS1_NS_DEFAULT_ENABLE` is true so that the behavior is backwards compatible.
