### PR TITLE
Able to rename the default ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 kube-ps1: Kubernetes prompt for bash and zsh
 ============================================
 
-A script that lets you add the current Kubernetes context and namespace configured on `kubectl` to your Bash/Zsh prompt strings (i.e. the `$PS1`).
+A script that lets you add the current Kubernetes context and namespace configured
+on `kubectl` to your Bash/Zsh prompt strings (i.e. the `$PS1`).
 
 Inspired by several tools used to simplify usage of `kubectl`.
 
@@ -13,8 +14,7 @@ Inspired by several tools used to simplify usage of `kubectl`.
 
 ![prompt demo](img/kube-ps1.gif)
 
-Installing
-----------
+## Installing
 
 This project is now available in brew ports!
 
@@ -22,39 +22,36 @@ This project is now available in brew ports!
 $ brew update
 $ brew install kube-ps1
 ```
-
 **From Source**
 
-1.	Clone this repository
-2.	Source the kube-ps1.sh in your `~/.zshrc` or your `~/.bashrc`
+1. Clone this repository
+2. Source the kube-ps1.sh in your `~/.zshrc` or your `~/.bashrc`
 
 Zsh:
-
 ```sh
 source /path/to/kube-ps1.sh
 PROMPT='$(kube_ps1)'$PROMPT
 ```
 
 Bash:
-
 ```sh
 source /path/to/kube-ps1.sh
 PS1="[\u@\h \W \$(kube_ps1)]\$ "
 ```
 
-Requirements
-------------
+## Requirements
 
-The default prompt assumes you have the `kubectl` command line utility installed. Official installation instructions and binaries are available:
+The default prompt assumes you have the `kubectl` command line utility installed.
+Official installation instructions and binaries are available:
 
 [Install and Set up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-If using this with OpenShift, the `oc` tool needs installed. It can be obtained from brew ports:
+If using this with OpenShift, the `oc` tool needs installed.  It can be obtained
+from brew ports:
 
 ```
 brew install openshift-cli
 ```
-
 or the source can be downloaded:
 
 [OC Client Tools](https://www.openshift.org/download.html)
@@ -71,20 +68,20 @@ If neither binary is available, the prompt will print the following:
 (<symbol>|BINARY-N/A:N/A)
 ```
 
-Helper utilities
-----------------
+## Helper utilities
 
 There are several great tools that make using kubectl very enjoyable:
 
--	[`kubectx` and `kubens`](https://github.com/ahmetb/kubectx) are great for fast switching between clusters and namespaces.
+- [`kubectx` and `kubens`](https://github.com/ahmetb/kubectx) are great for
+fast switching between clusters and namespaces.
 
-Tmux port
----------
+## Tmux port
 
-I have begun porting kube-ps1 to tmux as a status line plugin. If you prefer tmux, and like the functionality provided by kube-ps1, checkout the [kube-tmux](https://github.com/jonmosco/kube-tmux) project
+I have begun porting kube-ps1 to tmux as a status line plugin.  If you prefer
+tmux, and like the functionality provided by kube-ps1, checkout the
+[kube-tmux](https://github.com/jonmosco/kube-tmux) project
 
-Prompt Structure
-----------------
+## Prompt Structure
 
 The default prompt layout is:
 
@@ -98,10 +95,12 @@ If the current-context is not set, kube-ps1 will return the following:
 (<symbol>|N/A:N/A)
 ```
 
-Enabling/Disabling
-------------------
+## Enabling/Disabling
 
-If you want to stop showing Kubernetes status on your prompt string temporarily run `kubeoff`. To disable the prompt for all shell sessions, run `kubeoff -g`. You can enable it again in the current shell by running `kubeon`, and globally with `kubeon -g`.
+If you want to stop showing Kubernetes status on your prompt string temporarily
+run `kubeoff`. To disable the prompt for all shell sessions, run `kubeoff -g`.
+You can enable it again in the current shell by running `kubeon`, and globally
+with `kubeon -g`.
 
 ```
 kubeon     : turn on kube-ps1 status for this shell.  Takes presedense over
@@ -112,25 +111,26 @@ kubeoff    : turn off kube-ps1 status for this shell. Takes presedense over
 kubeoff -g : turn off kube-ps1 status globally
 ```
 
-Customization
--------------
+## Customization
 
-The default settings can be overridden in `~/.bashrc` or `~/.zshrc` by setting the following environment variables:
+The default settings can be overridden in `~/.bashrc` or `~/.zshrc` by setting
+the following environment variables:
 
-| Variable                     | Default   | Meaning                                                                                   |
-|:-----------------------------|:---------:|-------------------------------------------------------------------------------------------|
-| `KUBE_PS1_BINARY`            | `kubectl` | Default Kubernetes binary                                                                 |
-| `KUBE_PS1_NS_ENABLE`         |  `true`   | Display the namespace. If set to `false`, this will also disable `KUBE_PS1_DIVIDER`       |
-| `KUBE_PS1_NS_DEFAULT_STRING` | `default` | Display this when the active namespace is the `default`.                                  |
-| `KUBE_PS1_PREFIX`            |    `(`    | Prompt opening character                                                                  |
-| `KUBE_PS1_SYMBOL_ENABLE`     |  `true`   | Display the prompt Symbol. If set to `false`, this will also disable `KUBE_PS1_SEPARATOR` |
-| `KUBE_PS1_SYMBOL_DEFAULT`    |    `⎈`    | Default prompt symbol. Unicode `\u2388`                                                   |
-| `KUBE_PS1_SYMBOL_USE_IMG`    |  `false`  | ☸️ , Unicode `\u2638` as the prompt symbol                                                 |
-| `KUBE_PS1_SEPARATOR`         |  &#124;   | Separator between symbol and cluster name                                                 |
-| `KUBE_PS1_DIVIDER`           |    `:`    | Separator between cluster and namespace                                                   |
-| `KUBE_PS1_SUFFIX`            |    `)`    | Prompt closing character                                                                  |
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `KUBE_PS1_BINARY` | `kubectl` | Default Kubernetes binary |
+| `KUBE_PS1_NS_ENABLE` | `true` | Display the namespace. If set to `false`, this will also disable `KUBE_PS1_DIVIDER` |
+| `KUBE_PS1_NS_DEFAULT_STRING` | `default` | Display this string instead of the `default` namespace. |
+| `KUBE_PS1_PREFIX` | `(` | Prompt opening character  |
+| `KUBE_PS1_SYMBOL_ENABLE` | `true ` | Display the prompt Symbol. If set to `false`, this will also disable `KUBE_PS1_SEPARATOR` |
+| `KUBE_PS1_SYMBOL_DEFAULT` | `⎈ ` | Default prompt symbol. Unicode `\u2388` |
+| `KUBE_PS1_SYMBOL_USE_IMG` | `false` | ☸️  ,  Unicode `\u2638` as the prompt symbol |
+| `KUBE_PS1_SEPARATOR` | &#124; | Separator between symbol and cluster name |
+| `KUBE_PS1_DIVIDER` | `:` | Separator between cluster and namespace |
+| `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
 
-For terminals that do not support UTF-8, the symbol will be replaced with the string `k8s`.
+For terminals that do not support UTF-8, the symbol will be replaced with the
+string `k8s`.
 
 To disable a feature, set it to an empty string:
 
@@ -138,21 +138,23 @@ To disable a feature, set it to an empty string:
 KUBE_PS1_SEPARATOR=''
 ```
 
-Colors
-------
+## Colors
 
 The default colors are set with the following environment variables:
 
-| Variable                | Default | Meaning                                    |
-|:------------------------|:-------:|--------------------------------------------|
-| `KUBE_PS1_SYMBOL_COLOR` | `blue`  | Set default color of the Kubernetes symbol |
-| `KUBE_PS1_CTX_COLOR`    |  `red`  | Set default color of the cluster context   |
-| `KUBE_PS1_NS_COLOR`     | `cyan`  | Set default color of the cluster namespace |
-| `KUBE_PS1_BG_COLOR`     | `null`  | Set default color of the prompt background |
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `KUBE_PS1_SYMBOL_COLOR` | `blue` | Set default color of the Kubernetes symbol |
+| `KUBE_PS1_CTX_COLOR` | `red` | Set default color of the cluster context |
+| `KUBE_PS1_NS_COLOR` | `cyan` | Set default color of the cluster namespace |
+| `KUBE_PS1_BG_COLOR` | `null` | Set default color of the prompt background |
 
-Blue was used for the default symbol to match the Kubernetes color as closely as possible. Red was chosen as the cluster name to stand out, and cyan for the namespace.
+Blue was used for the default symbol to match the Kubernetes color as closely
+as possible. Red was chosen as the cluster name to stand out, and cyan for the
+namespace.
 
-Set the variable to an empty string if you do not want color for each prompt section:
+Set the variable to an empty string if you do not want color for each
+prompt section:
 
 ```
 KUBE_PS1_CTX_COLOR=''
@@ -164,30 +166,29 @@ Names are usable for the following colors:
 black, red, green, yellow, blue, magenta, cyan
 ```
 
-256 colors are available by specifying the numerical value as the variable argument.
+256 colors are available by specifying the numerical value as the variable
+argument.
 
 ### Bug Reports and shell configuration
 
-Due to the vast ways of customizing the shell, please try the prompt with a minimal configuration before submitting a bug report.
+Due to the vast ways of customizing the shell, please try the prompt with a
+minimal configuration before submitting a bug report.
 
 This can be done as follows for each shell before loading kube-ps1:
 
 Bash:
-
 ```
 bash --norc
 ```
 
 Zsh:
-
 ```
 zsh -f
 or
 zsh --no-rcs
 ```
 
-Contributors
-------------
+## Contributors
 
--	[Ahmet Alp Balkan](https://github.com/ahmetb)
--	Jared Yanovich
+* [Ahmet Alp Balkan](https://github.com/ahmetb)
+* Jared Yanovich

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 kube-ps1: Kubernetes prompt for bash and zsh
 ============================================
 
-A script that lets you add the current Kubernetes context and namespace configured
-on `kubectl` to your Bash/Zsh prompt strings (i.e. the `$PS1`).
+A script that lets you add the current Kubernetes context and namespace configured on `kubectl` to your Bash/Zsh prompt strings (i.e. the `$PS1`).
 
 Inspired by several tools used to simplify usage of `kubectl`.
 
@@ -14,7 +13,8 @@ Inspired by several tools used to simplify usage of `kubectl`.
 
 ![prompt demo](img/kube-ps1.gif)
 
-## Installing
+Installing
+----------
 
 This project is now available in brew ports!
 
@@ -22,36 +22,39 @@ This project is now available in brew ports!
 $ brew update
 $ brew install kube-ps1
 ```
+
 **From Source**
 
-1. Clone this repository
-2. Source the kube-ps1.sh in your `~/.zshrc` or your `~/.bashrc`
+1.	Clone this repository
+2.	Source the kube-ps1.sh in your `~/.zshrc` or your `~/.bashrc`
 
 Zsh:
+
 ```sh
 source /path/to/kube-ps1.sh
 PROMPT='$(kube_ps1)'$PROMPT
 ```
 
 Bash:
+
 ```sh
 source /path/to/kube-ps1.sh
 PS1="[\u@\h \W \$(kube_ps1)]\$ "
 ```
 
-## Requirements
+Requirements
+------------
 
-The default prompt assumes you have the `kubectl` command line utility installed.
-Official installation instructions and binaries are available:
+The default prompt assumes you have the `kubectl` command line utility installed. Official installation instructions and binaries are available:
 
 [Install and Set up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-If using this with OpenShift, the `oc` tool needs installed.  It can be obtained
-from brew ports:
+If using this with OpenShift, the `oc` tool needs installed. It can be obtained from brew ports:
 
 ```
 brew install openshift-cli
 ```
+
 or the source can be downloaded:
 
 [OC Client Tools](https://www.openshift.org/download.html)
@@ -68,20 +71,20 @@ If neither binary is available, the prompt will print the following:
 (<symbol>|BINARY-N/A:N/A)
 ```
 
-## Helper utilities
+Helper utilities
+----------------
 
 There are several great tools that make using kubectl very enjoyable:
 
-- [`kubectx` and `kubens`](https://github.com/ahmetb/kubectx) are great for
-fast switching between clusters and namespaces.
+-	[`kubectx` and `kubens`](https://github.com/ahmetb/kubectx) are great for fast switching between clusters and namespaces.
 
-## Tmux port
+Tmux port
+---------
 
-I have begun porting kube-ps1 to tmux as a status line plugin.  If you prefer
-tmux, and like the functionality provided by kube-ps1, checkout the
-[kube-tmux](https://github.com/jonmosco/kube-tmux) project
+I have begun porting kube-ps1 to tmux as a status line plugin. If you prefer tmux, and like the functionality provided by kube-ps1, checkout the [kube-tmux](https://github.com/jonmosco/kube-tmux) project
 
-## Prompt Structure
+Prompt Structure
+----------------
 
 The default prompt layout is:
 
@@ -95,12 +98,10 @@ If the current-context is not set, kube-ps1 will return the following:
 (<symbol>|N/A:N/A)
 ```
 
-## Enabling/Disabling
+Enabling/Disabling
+------------------
 
-If you want to stop showing Kubernetes status on your prompt string temporarily
-run `kubeoff`. To disable the prompt for all shell sessions, run `kubeoff -g`.
-You can enable it again in the current shell by running `kubeon`, and globally
-with `kubeon -g`.
+If you want to stop showing Kubernetes status on your prompt string temporarily run `kubeoff`. To disable the prompt for all shell sessions, run `kubeoff -g`. You can enable it again in the current shell by running `kubeon`, and globally with `kubeon -g`.
 
 ```
 kubeon     : turn on kube-ps1 status for this shell.  Takes presedense over
@@ -111,25 +112,25 @@ kubeoff    : turn off kube-ps1 status for this shell. Takes presedense over
 kubeoff -g : turn off kube-ps1 status globally
 ```
 
-## Customization
+Customization
+-------------
 
-The default settings can be overridden in `~/.bashrc` or `~/.zshrc` by setting
-the following environment variables:
+The default settings can be overridden in `~/.bashrc` or `~/.zshrc` by setting the following environment variables:
 
-| Variable | Default | Meaning |
-| :------- | :-----: | ------- |
-| `KUBE_PS1_BINARY` | `kubectl` | Default Kubernetes binary |
-| `KUBE_PS1_NS_ENABLE` | `true` | Display the namespace. If set to `false`, this will also disable `KUBE_PS1_DIVIDER` |
-| `KUBE_PS1_PREFIX` | `(` | Prompt opening character  |
-| `KUBE_PS1_SYMBOL_ENABLE` | `true ` | Display the prompt Symbol. If set to `false`, this will also disable `KUBE_PS1_SEPARATOR` |
-| `KUBE_PS1_SYMBOL_DEFAULT` | `⎈ ` | Default prompt symbol. Unicode `\u2388` |
-| `KUBE_PS1_SYMBOL_USE_IMG` | `false` | ☸️  ,  Unicode `\u2638` as the prompt symbol |
-| `KUBE_PS1_SEPARATOR` | &#124; | Separator between symbol and cluster name |
-| `KUBE_PS1_DIVIDER` | `:` | Separator between cluster and namespace |
-| `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
+| Variable                     | Default   | Meaning                                                                                   |
+|:-----------------------------|:---------:|-------------------------------------------------------------------------------------------|
+| `KUBE_PS1_BINARY`            | `kubectl` | Default Kubernetes binary                                                                 |
+| `KUBE_PS1_NS_ENABLE`         |  `true`   | Display the namespace. If set to `false`, this will also disable `KUBE_PS1_DIVIDER`       |
+| `KUBE_PS1_NS_DEFAULT_STRING` | `default` | Display this when the active namespace is the `default`.                                  |
+| `KUBE_PS1_PREFIX`            |    `(`    | Prompt opening character                                                                  |
+| `KUBE_PS1_SYMBOL_ENABLE`     |  `true`   | Display the prompt Symbol. If set to `false`, this will also disable `KUBE_PS1_SEPARATOR` |
+| `KUBE_PS1_SYMBOL_DEFAULT`    |    `⎈`    | Default prompt symbol. Unicode `\u2388`                                                   |
+| `KUBE_PS1_SYMBOL_USE_IMG`    |  `false`  | ☸️ , Unicode `\u2638` as the prompt symbol                                                 |
+| `KUBE_PS1_SEPARATOR`         |  &#124;   | Separator between symbol and cluster name                                                 |
+| `KUBE_PS1_DIVIDER`           |    `:`    | Separator between cluster and namespace                                                   |
+| `KUBE_PS1_SUFFIX`            |    `)`    | Prompt closing character                                                                  |
 
-For terminals that do not support UTF-8, the symbol will be replaced with the
-string `k8s`.
+For terminals that do not support UTF-8, the symbol will be replaced with the string `k8s`.
 
 To disable a feature, set it to an empty string:
 
@@ -137,23 +138,21 @@ To disable a feature, set it to an empty string:
 KUBE_PS1_SEPARATOR=''
 ```
 
-## Colors
+Colors
+------
 
 The default colors are set with the following environment variables:
 
-| Variable | Default | Meaning |
-| :------- | :-----: | ------- |
-| `KUBE_PS1_SYMBOL_COLOR` | `blue` | Set default color of the Kubernetes symbol |
-| `KUBE_PS1_CTX_COLOR` | `red` | Set default color of the cluster context |
-| `KUBE_PS1_NS_COLOR` | `cyan` | Set default color of the cluster namespace |
-| `KUBE_PS1_BG_COLOR` | `null` | Set default color of the prompt background |
+| Variable                | Default | Meaning                                    |
+|:------------------------|:-------:|--------------------------------------------|
+| `KUBE_PS1_SYMBOL_COLOR` | `blue`  | Set default color of the Kubernetes symbol |
+| `KUBE_PS1_CTX_COLOR`    |  `red`  | Set default color of the cluster context   |
+| `KUBE_PS1_NS_COLOR`     | `cyan`  | Set default color of the cluster namespace |
+| `KUBE_PS1_BG_COLOR`     | `null`  | Set default color of the prompt background |
 
-Blue was used for the default symbol to match the Kubernetes color as closely
-as possible. Red was chosen as the cluster name to stand out, and cyan for the
-namespace.
+Blue was used for the default symbol to match the Kubernetes color as closely as possible. Red was chosen as the cluster name to stand out, and cyan for the namespace.
 
-Set the variable to an empty string if you do not want color for each
-prompt section:
+Set the variable to an empty string if you do not want color for each prompt section:
 
 ```
 KUBE_PS1_CTX_COLOR=''
@@ -165,29 +164,30 @@ Names are usable for the following colors:
 black, red, green, yellow, blue, magenta, cyan
 ```
 
-256 colors are available by specifying the numerical value as the variable
-argument.
+256 colors are available by specifying the numerical value as the variable argument.
 
 ### Bug Reports and shell configuration
 
-Due to the vast ways of customizing the shell, please try the prompt with a
-minimal configuration before submitting a bug report.
+Due to the vast ways of customizing the shell, please try the prompt with a minimal configuration before submitting a bug report.
 
 This can be done as follows for each shell before loading kube-ps1:
 
 Bash:
+
 ```
 bash --norc
 ```
 
 Zsh:
+
 ```
 zsh -f
 or
 zsh --no-rcs
 ```
 
-## Contributors
+Contributors
+------------
 
-* [Ahmet Alp Balkan](https://github.com/ahmetb)
-* Jared Yanovich
+-	[Ahmet Alp Balkan](https://github.com/ahmetb)
+-	Jared Yanovich

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -244,7 +244,7 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
-    # If default is not desired, empty string in that case
+    # If default is not desired, replace it
     if [[ "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
       KUBE_PS1_NAMESPACE="${KUBE_PS1_NS_DEFAULT_STRING}"
     fi

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -27,7 +27,7 @@ KUBE_PS1_SYMBOL_ENABLE="${KUBE_PS1_SYMBOL_ENABLE:-true}"
 KUBE_PS1_SYMBOL_DEFAULT="${KUBE_PS1_SYMBOL_DEFAULT:-\u2388 }"
 KUBE_PS1_SYMBOL_USE_IMG="${KUBE_PS1_SYMBOL_USE_IMG:-false}"
 KUBE_PS1_NS_ENABLE="${KUBE_PS1_NS_ENABLE:-true}"
-KUBE_PS1_NS_DEFAULT_ENABLE="${KUBE_PS1_NS_DEFAULT_ENABLE:-true}"
+KUBE_PS1_NS_DEFAULT_STRING="${KUBE_PS1_NS_DEFAULT_STRING:-default}"
 KUBE_PS1_PREFIX="${KUBE_PS1_PREFIX-(}"
 KUBE_PS1_SEPARATOR="${KUBE_PS1_SEPARATOR-|}"
 KUBE_PS1_DIVIDER="${KUBE_PS1_DIVIDER-:}"
@@ -245,8 +245,8 @@ _kube_ps1_get_context_ns() {
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
     # If default is not desired, empty string in that case
-    if [[ "${KUBE_PS1_NS_DEFAULT_ENABLE}" == false && "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
-      KUBE_PS1_NAMESPACE=""
+    if [[ "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
+      KUBE_PS1_NAMESPACE="${KUBE_PS1_NS_DEFAULT_STRING}"
     fi
   fi
 }

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -27,6 +27,7 @@ KUBE_PS1_SYMBOL_ENABLE="${KUBE_PS1_SYMBOL_ENABLE:-true}"
 KUBE_PS1_SYMBOL_DEFAULT="${KUBE_PS1_SYMBOL_DEFAULT:-\u2388 }"
 KUBE_PS1_SYMBOL_USE_IMG="${KUBE_PS1_SYMBOL_USE_IMG:-false}"
 KUBE_PS1_NS_ENABLE="${KUBE_PS1_NS_ENABLE:-true}"
+KUBE_PS1_NS_DEFAULT_ENABLE="${KUBE_PS1_NS_DEFAULT_ENABLE:-true}"
 KUBE_PS1_PREFIX="${KUBE_PS1_PREFIX-(}"
 KUBE_PS1_SEPARATOR="${KUBE_PS1_SEPARATOR-|}"
 KUBE_PS1_DIVIDER="${KUBE_PS1_DIVIDER-:}"
@@ -243,6 +244,10 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
+    # If default is not desired, unset in that case
+    if [[ "${KUBE_PS1_NS_DEFAULT_ENABLE}" == false && "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
+      KUBE_PS1_NAMESPACE=""
+    fi
   fi
 }
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -244,7 +244,7 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
-    # If default is not desired, unset in that case
+    # If default is not desired, empty string in that case
     if [[ "${KUBE_PS1_NS_DEFAULT_ENABLE}" == false && "${KUBE_PS1_NAMESPACE}" == "default" ]]; then
       KUBE_PS1_NAMESPACE=""
     fi


### PR DESCRIPTION
The use case is that, for me, the `default` namespace doesn't need to show and take prompt space (I have a big prompt with git branches and so on!). Other people might prefer to keep a visual indicator of which namespace is active, even when it's the `default`, but perhaps they prefer something shorter.

By default, it doesn't do anything/is totally backwards compatible. But the user can set `KUBE_PS1_NS_DEFAULT_STRING` to whatever they please. In my case, as I don't want to show `default`, I just set to the empty string on my `.bashrc`: `KUBE_PS1_NS_DEFAULT_STRING=""`.