### PR TITLE
change method of deciding which stat command to use

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -181,9 +181,11 @@ _kube_ps1_file_newer_than() {
 
   if [[ "${KUBE_PS1_SHELL}" == "zsh" ]]; then
     mtime=$(stat +mtime "${file}")
-  elif ! (/usr/bin/stat --version &> /dev/null); then
+  elif stat -c "%s" /dev/null &> /dev/null; then
+    # GNU stat
     mtime=$(stat -c %Y "${file}")
   else
+    # BSD stat
     mtime=$(stat -f %m "$file")
   fi
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -37,7 +37,6 @@ KUBE_PS1_NS_COLOR="${KUBE_PS1_NS_COLOR-cyan}"
 KUBE_PS1_BG_COLOR="${KUBE_PS1_BG_COLOR}"
 KUBE_PS1_KUBECONFIG_CACHE="${KUBECONFIG}"
 KUBE_PS1_DISABLE_PATH="${HOME}/.kube/kube-ps1/disabled"
-KUBE_PS1_UNAME=$(uname)
 KUBE_PS1_LAST_TIME=0
 
 # Determine our shell
@@ -182,7 +181,7 @@ _kube_ps1_file_newer_than() {
 
   if [[ "${KUBE_PS1_SHELL}" == "zsh" ]]; then
     mtime=$(stat +mtime "${file}")
-  elif [[ "$KUBE_PS1_UNAME" == "Linux" ]]; then
+  elif ! (/usr/bin/stat --version &> /dev/null); then
     mtime=$(stat -c %Y "${file}")
   else
     mtime=$(stat -f %m "$file")


### PR DESCRIPTION
First of all, thank you for writing and sharing this code!

I'm on macOS High Sierra, but I prefer the GNU coreutils as I've been a linux user longer than a mac user. Because I put the non-prefixed versions of the coreutils programs in my `$PATH` before the BSD versions, I was getting an error when the stat command was being run.

So instead of using `uname` to determine which stat command to use, I modified it to run `stat --version` and if it did not fail, it will use the GNU version of stat instead of the BSD version. Since that was the only use of $KUBE_PS1_UNAME, I removed that variable to avoid having an unused variable in the code.

Please let me know if you have any concerns with this change.