### PR TITLE
add ability to modify display of cluster and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ the following environment variables:
 | `KUBE_PS1_SEPARATOR` | &#124; | Separator between symbol and cluster name |
 | `KUBE_PS1_DIVIDER` | `:` | Separator between cluster and namespace |
 | `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
+| `KUBE_PS1_CLUSTER_FUNCTION` | No default, must be user supplied | Function to customize how cluster is displayed |
+| `KUBE_PS1_NAMESPACE_FUNCTION` | No default, must be user supplied | Function to customize how namespace is displayed |
 
 For terminals that do not support UTF-8, the symbol will be replaced with the
 string `k8s`.
@@ -167,6 +169,37 @@ black, red, green, yellow, blue, magenta, cyan
 
 256 colors are available by specifying the numerical value as the variable
 argument.
+
+## Customize display of cluster name and namespace
+
+You can change how the cluster name and namespace are displayed using the `KUBE_PS1_CLUSTER_FUNCTION` and `KUBE_PS1_NAMESPACE_FUNCTION` variables respectively.
+
+For the following examples let's assume the following:
+
+cluster name: `sandbox.k8s.example.com`
+namespace: `alpha`
+
+If you're using domain style cluster names, your prompt will get quite long very quickly. Let's say you only want to display the first portion of the cluster name (`sandbox`), you could do that by adding the following:
+
+```
+function get_cluster_short() {
+  echo "$1" | cut -d . -f1
+}
+
+KUBE_PS1_CLUSTER_FUNCTION=get_cluster_short
+```
+
+The same pattern can be followed to customize the display of the namespace. Let's say you would prefer the namespace to be displayed in all uppercase (`ALPHA`), here's one way you could do that:
+
+```
+function get_namespace_upper() {
+    echo "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+export KUBE_PS1_NAMESPACE_FUNCTION=get_namespace_upper
+```
+
+In both cases, the variable is set to the name of the function, and you must have defined the function in your shell configuration before kube_ps1 is called. The function must accept a single parameter and echo out the final value.
 
 ### Bug Reports and shell configuration
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -39,6 +39,8 @@ KUBE_PS1_KUBECONFIG_CACHE="${KUBECONFIG}"
 KUBE_PS1_DISABLE_PATH="${HOME}/.kube/kube-ps1/disabled"
 KUBE_PS1_UNAME=$(uname)
 KUBE_PS1_LAST_TIME=0
+KUBE_PS1_CLUSTER_FUNCTION="${KUBE_PS1_CLUSTER_FUNCTION}"
+KUBE_PS1_NAMESPACE_FUNCTION="${KUBE_PS1_NAMESPACE_FUNCTION}"
 
 # Determine our shell
 if [ "${ZSH_VERSION-}" ]; then
@@ -235,6 +237,11 @@ _kube_ps1_get_context_ns() {
   fi
 
   KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
+
+  if [[ ! -z "${KUBE_PS1_CLUSTER_FUNCTION}" ]]; then
+    KUBE_PS1_CONTEXT=$($KUBE_PS1_CLUSTER_FUNCTION $KUBE_PS1_CONTEXT)
+  fi
+
   if [[ -z "${KUBE_PS1_CONTEXT}" ]]; then
     KUBE_PS1_CONTEXT="N/A"
     KUBE_PS1_NAMESPACE="N/A"
@@ -243,6 +250,11 @@ _kube_ps1_get_context_ns() {
     KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
     # Set namespace to 'default' if it is not defined
     KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
+
+    if [[ ! -z "${KUBE_PS1_NAMESPACE_FUNCTION}" ]]; then
+        KUBE_PS1_NAMESPACE=$($KUBE_PS1_NAMESPACE_FUNCTION $KUBE_PS1_NAMESPACE)
+    fi
+
   fi
 }
 


### PR DESCRIPTION
Our clusters use a domain-name style naming convention, which makes for a very long prompt when the whole cluster name is used. This PR adds two new variables that can be used to customize the display of the cluster and the namespace using a user-provided function.

I tried to give good explanations on how to use these in the README, please let me know if it's unclear or needs any additional changes.

Thanks!