### PR TITLE
Do nothing if KUBE_PS1_CONTEXT is empty

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -308,6 +308,7 @@ kubeoff() {
 # Build our prompt
 kube_ps1() {
   [[ "${KUBE_PS1_ENABLED}" == "off" ]] && return
+  [[ -z "${KUBE_PS1_CONTEXT}" ]] && return
 
   local KUBE_PS1
   local KUBE_PS1_RESET_COLOR="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"


### PR DESCRIPTION
I keep `~/.kube/config` empty and use separate config files for each cluster and use a script to set `KUBECONFIG` to switch between them. That means in some cases there's no context set and I get the kube-ps1 icon on my prompt followed by a empty space. This PR hides it until a context is set.