### PR TITLE
adding fix for calling zsh stat function to not conflict with external stat. Fix for #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Inspired by several tools used to simplify usage of `kubectl`.
 
 ## Installing
 
-This project is now available in brew ports!
+### MacOS
+
+Homebrew package manager:
 
 ```
 $ brew update
 $ brew install kube-ps1
 ```
-**From Source**
+### From Source
 
 1. Clone this repository
 2. Source the kube-ps1.sh in your `~/.zshrc` or your `~/.bashrc`

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -58,7 +58,7 @@ _kube_ps1_init() {
       setopt PROMPT_SUBST
       autoload -U add-zsh-hook
       add-zsh-hook precmd _kube_ps1_update_cache
-      zmodload zsh/stat
+      zmodload -F zsh/stat b:zstat
       zmodload zsh/datetime
       ;;
     "bash")
@@ -181,7 +181,7 @@ _kube_ps1_file_newer_than() {
   local check_time=$2
 
   if [[ "${KUBE_PS1_SHELL}" == "zsh" ]]; then
-    mtime=$(stat -L +mtime "${file}")
+    mtime=$(zstat -L +mtime "${file}")
   elif stat -c "%s" /dev/null &> /dev/null; then
     # GNU stat
     mtime=$(stat -L -c %Y "${file}")


### PR DESCRIPTION
http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fstat-Module

Zsh has the ability to call the stat module and prepending it with a `z` to not conflict with the external stat.  