### PR TITLE
Move update_cache to the end of PROMPT_COMMAND

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -68,7 +68,7 @@ _kube_ps1_init() {
       _KUBE_PS1_CLOSE_ESC=$'\002'
       _KUBE_PS1_DEFAULT_BG=$'\033[49m'
       _KUBE_PS1_DEFAULT_FG=$'\033[39m'
-      PROMPT_COMMAND="_kube_ps1_update_cache;${PROMPT_COMMAND:-:}"
+      PROMPT_COMMAND="${PROMPT_COMMAND:-:};_kube_ps1_update_cache"
       ;;
   esac
 }


### PR DESCRIPTION
Injecting the call at the start of PROMPT_COMMAND clears the error
status, so it's no longer possible to capture the `$?` variable.

I've just moved it to the end, which should be harmless.