### PR TITLE
Hide status based on custom function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ kubeoff    : turn off kube-ps1 status for this shell. Takes precedence over
 kubeoff -g : turn off kube-ps1 status globally
 ```
 
+It is also possible to disable the display of the kube-ps1 status based on
+custom conditions by setting the `KUBE_PS1_HIDE_FUNCTION` variable to the name
+of a function. When that function returns a value of `0`, the entire Kubernetes
+status remains hidden.
+
+```sh
+# Example: keep kube-ps1 status hidden when current context equals 'minikube'
+hide_kube_ps1() {
+    [[ "$KUBE_PS1_CONTEXT" == 'minikube' ]]
+}
+KUBE_PS1_HIDE_FUNCTION=hide_kube_ps1
+```
+
 ## Customization
 
 The default settings can be overridden in `~/.bashrc` or `~/.zshrc` by setting
@@ -132,8 +145,10 @@ the following environment variables:
 | `KUBE_PS1_SEPARATOR` | &#124; | Separator between symbol and cluster name |
 | `KUBE_PS1_DIVIDER` | `:` | Separator between cluster and namespace |
 | `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
-| `KUBE_PS1_CLUSTER_FUNCTION` | No default, must be user supplied | Function to customize how cluster is displayed |
-| `KUBE_PS1_NAMESPACE_FUNCTION` | No default, must be user supplied | Function to customize how namespace is displayed |
+| `KUBE_PS1_CLUSTER_FUNCTION` | (none)\* | Function to customize how cluster is displayed |
+| `KUBE_PS1_NAMESPACE_FUNCTION` | (none)\* | Function to customize how namespace is displayed |
+
+\* _must be user supplied_
 
 For terminals that do not support UTF-8, the symbol will be replaced with the
 string `k8s`.

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -326,6 +326,7 @@ kubeoff() {
 # Build our prompt
 kube_ps1() {
   [[ "${KUBE_PS1_ENABLED}" == "off" ]] && return
+  [[ -n "${KUBE_PS1_HIDE_FUNCTION}" ]] && $KUBE_PS1_HIDE_FUNCTION && return
   [[ -z "${KUBE_PS1_CONTEXT}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] && return
 
   local KUBE_PS1


### PR DESCRIPTION
#### tl;dr

Hide kube-ps1 when the `KUBE_PS1_HIDE_FUNCTION` function is defined and returns `0`.

#### Description

I find it quite handy to be able to disable prompt modules selectively, depending on the context of my workspace. For example, I have no reason to be displaying a Kubernetes status when I'm currently not working on a cluster.

This PR adds a very simple mechanism to allow users to _hide_ the kube-ps1 status based on the return value of a custom function. I used the term _hide_ instead of _disable_ because `_kube_ps1_update_cache()` is still being invoked.

#### Examples

A few basic but typical use-cases come to my mind:

```bash
# Hide kube-ps1 when the current context is "minikube".
hide_kube_ps1() {
    [[ "$KUBE_PS1_CONTEXT" == 'minikube' ]]
}
```

```bash
# Hide kube-ps1 when KUBECONFIG is unset.
hide_kube_ps1() {
    [[ -z "${KUBECONFIG:-}" ]]
}
```

```bash
# Hide kube-ps1 when the current cluster is unreachable.
hide_kube_ps1() {
    ! kubectl cluster-info --request-timeout=1s &>/dev/null
}
```

```bash
# Hide kube-ps1 when on a given network (macOS).
hide_kube_ps1() {
    route -n get default | awk '$1 == "gateway:" && $2 !~ /^192\.168\.100\./ { exit 1 }'
}
```