### PR TITLE
Avoid producing double semicolon in $PROMPT_COMMAND

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -69,7 +69,10 @@ _kube_ps1_init() {
       _KUBE_PS1_CLOSE_ESC=$'\002'
       _KUBE_PS1_DEFAULT_BG=$'\033[49m'
       _KUBE_PS1_DEFAULT_FG=$'\033[39m'
-      PROMPT_COMMAND="${PROMPT_COMMAND:-:};_kube_ps1_update_cache"
+      if [[ -n $PROMPT_COMMAND ]] && [[ $PROMPT_COMMAND != *\; ]]; then
+        PROMPT_COMMAND="${PROMPT_COMMAND};"
+      fi
+      PROMPT_COMMAND="${PROMPT_COMMAND} _kube_ps1_update_cache"
       ;;
   esac
 }


### PR DESCRIPTION
If [the code](https://github.com/jonmosco/kube-ps1/blob/953c7b26cab8ca09a5092fc169c66a4f0fff5db6/kube-ps1.sh#L72)

    PROMPT_COMMAND="${PROMPT_COMMAND:-:};_kube_ps1_update_cache"

is sourced when the `$PROMPT_COMMAND` already ends with a semicolon, a double semicolon is produced in that variable, leading to constant error messages of

    bash: PROMPT_COMMAND: line 7: syntax error near unexpected token `;;'

My fix checks to see if `$PROMPT_COMMAND` has been declared, and if so, whether or not it already ends in a semicolon. Only if it does not is the semicolon added, followed by `_kube_ps1_update_cache`.