### PR TITLE
Fix unicode character for newer macos versions

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -152,7 +152,7 @@ _kube_ps1_symbol() {
       if ((BASH_VERSINFO[0] >= 4)) && [[ $'\u2388 ' != "\\u2388 " ]]; then
         KUBE_PS1_SYMBOL="${KUBE_PS1_SYMBOL_DEFAULT}"
         # KUBE_PS1_SYMBOL=$'\u2388 '
-        KUBE_PS1_SYMBOL_IMG=$'\u2638 '
+        KUBE_PS1_SYMBOL_IMG=$'\u2638\ufe0f '
       else
         KUBE_PS1_SYMBOL=$'\xE2\x8E\x88 '
         KUBE_PS1_SYMBOL_IMG=$'\xE2\x98\xB8 '


### PR DESCRIPTION
On newer macos versions (Catalina, 10.15), the emoji rendered for \u2638 is now monochrome.

Before 10.15:

![Capture d’écran 2019-10-11 à 09 25 52](https://user-images.githubusercontent.com/1652160/66633109-5caa3f00-ec0a-11e9-93ae-7031c59af860.png)

After:

![Capture d’écran 2019-10-11 à 09 24 52](https://user-images.githubusercontent.com/1652160/66633137-70ee3c00-ec0a-11e9-96fc-832473411a68.png)

