### PR TITLE
Better output for AWS EKS

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -235,6 +235,12 @@ _kube_ps1_get_context() {
     # Set namespace to 'N/A' if it is not defined
     KUBE_PS1_CONTEXT="${KUBE_PS1_CONTEXT:-N/A}"
 
+    # Format AWS EKS cluster
+    regex="^arn:aws:eks:[a-z0-9-]+:[0-9]+:cluster\/[0-9A-Za-z][A-Za-z0-9\-_]*"
+    if [[ $KUBE_PS1_CONTEXT =~ "$regex" ]]; then
+      KUBE_PS1_CONTEXT=${KUBE_PS1_CONTEXT#*cluster/}
+    fi
+
     if [[ ! -z "${KUBE_PS1_CLUSTER_FUNCTION}" ]]; then
       KUBE_PS1_CONTEXT=$($KUBE_PS1_CLUSTER_FUNCTION $KUBE_PS1_CONTEXT)
     fi


### PR DESCRIPTION
Hey there!
Whoever is using an AWS EKS cluster sees the following prompt:
`➜  (⎈ |arn:aws:eks:us-west-2:123456789012:cluster/unicorn:default)`
Which is obviously not that pleasant :blush:

This PR should change this to:
`➜  (⎈ |unicorn:default)`

*P.S: opening an improved version of this change here as suggested on [ohmyzsh](https://github.com/ohmyzsh/ohmyzsh/pull/7974)*