### PR TITLE
fix zstat use -L option to follow symbol link wrongly

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -184,7 +184,7 @@ _kube_ps1_file_newer_than() {
   local check_time=$2
 
   if [[ "${KUBE_PS1_SHELL}" == "zsh" ]]; then
-    mtime=$(zstat -L +mtime "${file}")
+    mtime=$(zstat +mtime "${file}")
   elif stat -c "%s" /dev/null &> /dev/null; then
     # GNU stat
     mtime=$(stat -L -c %Y "${file}")


### PR DESCRIPTION
fix https://github.com/ohmyzsh/ohmyzsh/issues/8786#issue-590928867