### PR TITLE
optimization(context): speed up retrieval of current-context by looking at kube config file

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -231,7 +231,7 @@ _kube_ps1_update_cache() {
 
 _kube_ps1_get_context() {
   if [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]]; then
-    KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
+    KUBE_PS1_CONTEXT="$(grep 'current-context' "${KUBECONFIG:-${HOME}/.kube/config}" | awk '{print $2}' 2>/dev/null)"
     # Set namespace to 'N/A' if it is not defined
     KUBE_PS1_CONTEXT="${KUBE_PS1_CONTEXT:-N/A}"
 


### PR DESCRIPTION
### Goal
Speed up the time to get the general context.

### Why?
We are using AWS EKS with IAM authentication when accessing kubernetes. This can require an OAuth action when executing a `kubectl` command. Example `aws-okta exec developer -- kubectl`. We have noticed that there can be a 1 to 2 second delay when the prompt needs to be updated.

### Change
Rely on the `$HOME/.kube/config` to maintain the correct setting for the `current-context` and use common tools like `grep` and `awk` to quickly pull the context.

Simple wall clock comparisons:

Before:
```
[⎈ arn:aws:eks:notgonnapostthat:cluster/goodway-staging] clok ~/github/kube-ps1 (git::opt/speed-up-context):
$ time aws-okta exec developer -- kubectl config current-context
arn:aws:eks:notgonnapostthat:cluster/goodway-staging

real	0m1.147s
user	0m0.242s
sys	0m0.259s
```

After:
```
[⎈ arn:aws:eks:notgonnapostthat:cluster/goodway-staging] clok ~/github/kube-ps1 (git::opt/speed-up-context):
$ time grep 'current-context' "${KUBECONFIG:-${HOME}/.kube/config}" | awk '{print $2}' 2>/dev/null
arn:aws:eks:notgonnapostthat:cluster/goodway-staging

real	0m0.008s
user	0m0.003s
sys	0m0.006s
```