### PR TITLE
Adding ctime support when checking for changes

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -185,7 +185,7 @@ _kube_ps1_file_newer_than() {
 
   if [[ "${KUBE_PS1_SHELL}" == "zsh" ]]; then
     mtime=$(zstat +mtime "${file}")
-    ctime=0
+    ctime=$(zstat +ctime "${file}")
   elif stat -c "%s" /dev/null &> /dev/null; then
     # GNU stat
     stats=$(stat -L -c "%Y:%Z" "${file}")


### PR DESCRIPTION
https://github.com/mumoshu/config-registry uses hard links to update ~/.kube/config.  kube-ps1 was not detecting changes to the context because the mtime was not being updated when the kube config hard link was updated. Detecting changes to ctime and mtime solved this.

I could not figure out how to get zstat to return mtime and ctime at the same time so I had to do it with two calls.