### PR TITLE
adding ability to change the prefix and suffix color.  Resolves #79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### kube-ps1 project CHANGELOG
+## kube-ps1 project CHANGELOG
 
-## (UNRELEASED)
+### [UNRELEASED]
 
+* Added ability to change the color of `KUBE_PS1_PREFIX` and `KUBE_PS1_SUFFIX` ([#79](https://github.com/jonmosco/kube-ps1/issues/79))
 * Added option to turn off image padding.  Defaults to `true`.  There were some troubles with terminals overlapping the symbol ([#126](https://github.com/jonmosco/kube-ps1/issues/126))
 
 ### IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ The default colors are set with the following environment variables:
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
+| `KUBE_PS1_PREFIX_COLOR` | `null` | Set default color of the prompt prefix |
 | `KUBE_PS1_SYMBOL_COLOR` | `blue` | Set default color of the Kubernetes symbol |
 | `KUBE_PS1_CTX_COLOR` | `red` | Set default color of the context |
+| `KUBE_PS1_SUFFIX_COLOR` | `null` | Set default color of the prompt suffix |
 | `KUBE_PS1_NS_COLOR` | `cyan` | Set default color of the namespace |
 | `KUBE_PS1_BG_COLOR` | `null` | Set default color of the prompt background |
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -346,7 +346,11 @@ kube_ps1() {
   [[ -n "${KUBE_PS1_BG_COLOR}" ]] && KUBE_PS1+="$(_kube_ps1_color_bg ${KUBE_PS1_BG_COLOR})"
 
   # Prefix
-  [[ -n "${KUBE_PS1_PREFIX}" ]] && KUBE_PS1+="${KUBE_PS1_PREFIX}"
+  if [[ -z "${KUBE_PS1_PREFIX_COLOR:-}" ]] && [[ -n "${KUBE_PS1_PREFIX}" ]]; then
+      KUBE_PS1+="${KUBE_PS1_PREFIX}"
+  else
+      KUBE_PS1+="$(_kube_ps1_color_fg $KUBE_PS1_PREFIX_COLOR)${KUBE_PS1_PREFIX}${KUBE_PS1_RESET_COLOR}"
+  fi
 
   # Symbol
   KUBE_PS1+="$(_kube_ps1_color_fg $KUBE_PS1_SYMBOL_COLOR)$(_kube_ps1_symbol)${KUBE_PS1_RESET_COLOR}"
@@ -369,7 +373,11 @@ kube_ps1() {
   fi
 
   # Suffix
-  [[ -n "${KUBE_PS1_SUFFIX}" ]] && KUBE_PS1+="${KUBE_PS1_SUFFIX}"
+  if [[ -z "${KUBE_PS1_SUFFIX_COLOR:-}" ]] && [[ -n "${KUBE_PS1_SUFFIX}" ]]; then
+      KUBE_PS1+="${KUBE_PS1_SUFFIX}"
+  else
+      KUBE_PS1+="$(_kube_ps1_color_fg $KUBE_PS1_SUFFIX_COLOR)${KUBE_PS1_SUFFIX}${KUBE_PS1_RESET_COLOR}"
+  fi
 
   # Close Background color if defined
   [[ -n "${KUBE_PS1_BG_COLOR}" ]] && KUBE_PS1+="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_BG}${_KUBE_PS1_CLOSE_ESC}"


### PR DESCRIPTION
resolves #79 

Exposes the variables `KUBE_PS1_PREFIX_COLOR` and `KUBE_PS1_SUFFIX_COLOR` to allow customization of each, respectively. 