### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Homebrew package manager:
 $ brew update
 $ brew install kube-ps1
 ```
+
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `kube-ps1` in zsh, bash, or fish with one click.
+
+<a href="https://fig.io/plugins/other/kube-ps1" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### From Source
 
 1. Clone this repository


### PR DESCRIPTION
We recently listed Kube PS1 on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. We have over 100k users that we think could benefit from this. 

Thanks so much and please let me know if you have any questions!

