### PR TITLE
Fix reference to undefined ${OPEN,CLOSE}_ESC

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -140,7 +140,7 @@ _kube_ps1_color_bg() {
       KUBE_PS1_BG_CODE="${DEFAULT_BG}"
     fi
   fi
-  echo ${OPEN_ESC}${KUBE_PS1_BG_CODE}${CLOSE_ESC}
+  echo ${_KUBE_PS1_OPEN_ESC}${KUBE_PS1_BG_CODE}${_KUBE_PS1_CLOSE_ESC}
 }
 
 _kube_ps1_binary_check() {


### PR DESCRIPTION
When kube-ps1 is invoked with a custom `$KUBE_PS1_BG_COLOR`, the resulting prompt is output without the correct escape bytes around the background color sequence. This causes shell history recall to wrap incorrectly and corrupt the line, as described in [this BashFAQ](http://mywiki.wooledge.org/BashFAQ/053).

This was caused by a reference to a nonexistent pair of variables, `$OPEN_ESC` and `$CLOSE_ESC`, in the `_kube_ps1_color_bg` function. This PR replaces these with `$_KUBE_PS1_OPEN_ESC` and `_KUBE_PS1_CLOSE_ESC`, which appears to be the original intention.