### PR TITLE
docs(README.md): Removing typos in the README file to use copy button correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Inspired by several tools used to simplify usage of `kubectl`.
 
 Homebrew package manager:
 
-```
-$ brew update
-$ brew install kube-ps1
+```sh
+brew update
+brew install kube-ps1
 ```
 
 ### Arch Linux


### PR DESCRIPTION
In the section of brew commands, when the copy button has been used, the character `$` is copied together with the brew command and It causes an error on the user terminal.

Removing the `$` character promotes the best experience for users.