### PR TITLE
Build prompt when necessary

### DIFF
--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -37,7 +37,6 @@ KUBE_PS1_SUFFIX="${KUBE_PS1_SUFFIX-)}"
 _KUBE_PS1_KUBECONFIG_CACHE="${KUBECONFIG}"
 _KUBE_PS1_DISABLE_PATH="${HOME}/.kube/kube-ps1/disabled"
 _KUBE_PS1_LAST_TIME=0
-_KUBE_PS1_NEEDS_REBUILD=true
 _KUBE_PS1=""
 
 # Determine our shell
@@ -64,7 +63,6 @@ _kube_ps1_init() {
       setopt PROMPT_SUBST
       autoload -U add-zsh-hook
       add-zsh-hook precmd _kube_ps1_prompt_update
-      add-zsh-hook precmd _build_ps1_prompt
       zmodload -F zsh/stat b:zstat
       zmodload zsh/datetime
       ;;
@@ -73,7 +71,7 @@ _kube_ps1_init() {
       _KUBE_PS1_CLOSE_ESC=$'\002'
       _KUBE_PS1_DEFAULT_BG=$'\033[49m'
       _KUBE_PS1_DEFAULT_FG=$'\033[39m'
-      [[ $PROMPT_COMMAND =~ "_kube_ps1_prompt_update;_build_ps1_prompt" ]] || PROMPT_COMMAND="_kube_ps1_prompt_update;_build_ps1_prompt;${PROMPT_COMMAND:-:}"
+      [[ $PROMPT_COMMAND =~ _kube_ps1_prompt_update ]] || PROMPT_COMMAND="_kube_ps1_prompt_update;${PROMPT_COMMAND:-:}"
       ;;
   esac
 }
@@ -236,7 +234,7 @@ _kube_ps1_prompt_update() {
     # No ability to fetch context/namespace; display N/A.
     KUBE_PS1_CONTEXT="BINARY-N/A"
     KUBE_PS1_NAMESPACE="N/A"
-    _KUBE_PS1_NEEDS_REBUILD=true
+    _build_ps1_prompt
     return $return_code
   fi
 
@@ -244,7 +242,7 @@ _kube_ps1_prompt_update() {
     # User changed KUBECONFIG; unconditionally refetch.
     _KUBE_PS1_KUBECONFIG_CACHE=${KUBECONFIG}
     _kube_ps1_get_context_ns
-    _KUBE_PS1_NEEDS_REBUILD=true
+    _build_ps1_prompt
     return $return_code
   fi
 
@@ -258,14 +256,14 @@ _kube_ps1_prompt_update() {
     config_file_cache+=":${conf}"
     if _kube_ps1_file_newer_than "${conf}" "${_KUBE_PS1_LAST_TIME}"; then
       _kube_ps1_get_context_ns
-      _KUBE_PS1_NEEDS_REBUILD=true
+      _build_ps1_prompt
       return $return_code
     fi
   done
 
   if [[ "${config_file_cache}" != "${_KUBE_PS1_CFGFILES_READ_CACHE}" ]]; then
     _kube_ps1_get_context_ns
-    _KUBE_PS1_NEEDS_REBUILD=true
+    _build_ps1_prompt
     return $return_code
   fi
 
@@ -352,12 +350,6 @@ EOF
 
 # Build our prompt
 _build_ps1_prompt() {
-  local return_code=$?
-
-  [[ "${KUBE_PS1_ENABLED}" == "off" ]] && return "$return_code"
-  [[ -z "${KUBE_PS1_CONTEXT}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] && return "$return_code"
-  [[ "${_KUBE_PS1_NEEDS_REBUILD}" == "true" ]] || return "$return_code"
-
   local KUBE_PS1
   local KUBE_PS1_RESET_COLOR="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"
 
@@ -401,7 +393,6 @@ _build_ps1_prompt() {
   # Close Background color if defined
   [[ -n "${KUBE_PS1_BG_COLOR}" ]] && KUBE_PS1+="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_BG}${_KUBE_PS1_CLOSE_ESC}"
 
-  _KUBE_PS1_NEEDS_REBUILD=false
   _KUBE_PS1="${KUBE_PS1}"
 }
 


### PR DESCRIPTION
This PR aims to HEAVILY improve performance by running the "build" portion of the prompt only when necessary.

Before, the script checked for colors, shell, and many commands on every prompt. Now, we set a variable to ensure the prompt is rebuilt only when necessary.

Now, a few things about this PR:
1. I have NOT tested for ZSH, at all. I don't use ZSH, so I wouldn't even know how to validate it.
2. I did test for bash as much as I could, and I noticed no problems, but I'm sure there's some stupid edge cases I haven't accounted for.

Overall, I didn't find a way to "benchmark" this. I had been running a personal, heavily modified version of this script, which only accounts for Bash, Linux, `tput` being available, etc, and while doing that and building the prompt, I get a 15x (yes 1500%) speed improvement, which I benchmarked like this: `time { for i in {1..1000}; do kube_ps1 > /dev/null; done }`.

However, this doesn't work for this script since we do it "lazily". I'd appreciate any way to benchmark this. I'd also appreciate some validation on ZSH before I mark this PR ready to review.