### PR TITLE
Add configuration option to hide kube-ps1 prompt if no context is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ the following variables:
 | `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
 | `KUBE_PS1_CLUSTER_FUNCTION` | No default, must be user supplied | Function to customize how cluster is displayed |
 | `KUBE_PS1_NAMESPACE_FUNCTION` | No default, must be user supplied | Function to customize how namespace is displayed |
+| `KUBE_PS1_HIDE_IF_NOCONTEXT` | `false` | Hide the kube-ps1 prompt if no context is set |
 
 To disable a feature, set it to an empty string:
 

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -34,6 +34,8 @@ KUBE_PS1_SEPARATOR="${KUBE_PS1_SEPARATOR-|}"
 KUBE_PS1_DIVIDER="${KUBE_PS1_DIVIDER-:}"
 KUBE_PS1_SUFFIX="${KUBE_PS1_SUFFIX-)}"
 
+KUBE_PS1_HIDE_IF_NOCONTEXT="${KUBE_PS1_HIDE_IF_NOCONTEXT:-false}"
+
 _KUBE_PS1_KUBECONFIG_CACHE="${KUBECONFIG}"
 _KUBE_PS1_DISABLE_PATH="${HOME}/.kube/kube-ps1/disabled"
 _KUBE_PS1_LAST_TIME=0
@@ -376,6 +378,8 @@ kubeoff() {
 kube_ps1() {
   [[ "${KUBE_PS1_ENABLED}" == "off" ]] && return
   [[ -z "${KUBE_PS1_CONTEXT}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] && return
+  [[ "${KUBE_PS1_CONTEXT}" == "N/A" ]] && [[ ${KUBE_PS1_HIDE_IF_NOCONTEXT} == false ]] && return
+
 
   local KUBE_PS1
   local KUBE_PS1_RESET_COLOR="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"


### PR DESCRIPTION
- Introduces `KUBE_PS1_HIDE_IF_NOCONTEXT` (default: false) to hide the kube-ps1 prompt part when no context is set
- Updates `kube_ps1()` to check if the current context is set to "N/A" and hide the kube-ps1 prompt part if the option is enabled.
- Updates README to document the `KUBE_PS1_HIDE_IF_NOCONTEXT` option.

Implements #179