### PR TITLE
feat: add environment indicator to the prompt layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The default prompt layout is:
 ```sh
 (<symbol>|<context>:<namespace>)
 ```
+You can enable kube environment context (like dev/staging/test/prod) via `KUBE_PS1_ENV_CTX_ENABLE=true`. In this case, the layout will be:
+```sh
+[<kube-environment>] (<symbol>|<context>:<namespace>)
+```
 
 If the current-context is not set, kube-ps1 will return the following:
 
@@ -204,6 +208,23 @@ the following variables:
 | `KUBE_PS1_CTX_COLOR_FUNCTION` | No default, must be user supplied | Function to customize context color based on context name |
 | `KUBE_PS1_HIDE_IF_NOCONTEXT` | `false` | Hide the kube-ps1 prompt if no context is set |
 
+For more control over the Kubernetes environment context, you can adjust:
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `KUBE_PS1_ENV_CTX_ENABLE` | `false` | Extract environment identifiers from context and display them as a separate block in square brackets, e.g `testing-mycluster` becomes `[test] mycluster` |
+| `KUBE_PS1_ENV_PADDING` | one space | Padding (spaces or characters) added around the environment block |
+| `KUBE_PS1_ENV_OPEN_SYMBOL` | `[` | Opening symbol used for the environment block |
+| `KUBE_PS1_ENV_CLOSE_SYMBOL` | `]` | Closing symbol used for the environment block |
+| `KUBE_PS1_ENV_PROD_LABEL` | `prod` | Set default production label |
+| `KUBE_PS1_ENV_STG_LABEL` | `stag` | Set default staging label |
+| `KUBE_PS1_ENV_TEST_LABEL` | `test` | Set default testing label |
+| `KUBE_PS1_ENV_DEV_LABEL` | `dev` | Set default developing label |
+| `KUBE_PS1_ENV_PROD_RE` | `(production\|prod)-` | Regex used to detect production in the context name |
+| `KUBE_PS1_ENV_STG_RE` | `(staging\|stg)-` | Regex used to detect staging in the context name |
+| `KUBE_PS1_ENV_TEST_RE` | `(testing\|test)-` | Regex used to detect test in the context name |
+| `KUBE_PS1_ENV_DEV_RE` | `dev(elop(ment)?)?-` | Regex used to detect development in the context name |
+
 To disable a feature, set it to an empty string:
 
 ```sh
@@ -226,6 +247,15 @@ The default colors are set with the following variables:
 Blue was used for the default symbol to match the Kubernetes color as closely
 as possible. Red was chosen as the context name to stand out, and cyan for the
 namespace.
+
+If `KUBE_PS1_ENV_CTX_ENABLE` is set to `true`, you can also modify:
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `KUBE_PS1_ENV_PROD_COLOR` | `red` | Set default color of the production environment |
+| `KUBE_PS1_ENV_STG_COLOR` | `yellow` | Set default color of the staging environment |
+| `KUBE_PS1_ENV_TEST_COLOR` | `green` | Set default color of the testing environment |
+| `KUBE_PS1_ENV_DEV_COLOR` | `blue` | Set default color of the development environment |
 
 Set the variable to an empty string if you do not want color for each
 prompt section:

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -356,7 +356,7 @@ _kube_ps1_set_env_ctx() {
 
   for ctx in prod test dev stg; do
     if grep -qE "${KUBE_PS1_ENV[${ctx}_re]}" <<< "${KUBE_PS1_CONTEXT}"; then
-      sed -E "s/${KUBE_PS1_ENV[${ctx}_re]}//g" <<< "${KUBE_PS1_CONTEXT}" > /dev/null
+      KUBE_PS1_CONTEXT="$(sed -E "s/${KUBE_PS1_ENV[${ctx}_re]}//g" <<< "${KUBE_PS1_CONTEXT}")"
       ctx_color="$(_kube_ps1_color_fg "${KUBE_PS1_ENV[${ctx}_color]}")"
       ctx_label="${KUBE_PS1_ENV[${ctx}_label]}"
     fi

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -36,6 +36,31 @@ KUBE_PS1_SUFFIX="${KUBE_PS1_SUFFIX-)}"
 
 KUBE_PS1_HIDE_IF_NOCONTEXT="${KUBE_PS1_HIDE_IF_NOCONTEXT:-false}"
 
+# Kube environment variables
+KUBE_PS1_ENV_CTX_ENABLE="${KUBE_PS1_ENV_CTX_ENABLE:-false}"
+KUBE_PS1_ENV_PADDING="${KUBE_PS1_ENV_PADDING:- }"
+
+KUBE_PS1_ENV_OPEN_SYMBOL="${KUBE_PS1_ENV_OPEN_SYMBOL:-[}"
+KUBE_PS1_ENV_CLOSE_SYMBOL="${KUBE_PS1_ENV_CLOSE_SYMBOL:-]}"
+
+declare -Ag KUBE_PS1_ENV=(
+    [prod_color]="${KUBE_PS1_ENV_PROD_COLOR:-red}"
+    [prod_label]="${KUBE_PS1_ENV_PROD_LABEL:-prod}"
+    [prod_re]="${KUBE_PS1_ENV_PROD_RE:-(production|prod)-}"
+
+    [stg_color]="${KUBE_PS1_ENV_STG_COLOR:-yellow}"
+    [stg_label]="${KUBE_PS1_ENV_STG_LABEL:-stag}"
+    [stg_re]="${KUBE_PS1_ENV_STG_RE:-(staging|stg)-}"
+
+    [test_color]="${KUBE_PS1_ENV_TEST_COLOR:-green}"
+    [test_label]="${KUBE_PS1_ENV_TEST_LABEL:-test}"
+    [test_re]="${KUBE_PS1_ENV_TEST_RE:-(testing|test)-}"
+
+    [dev_color]="${KUBE_PS1_ENV_DEV_COLOR:-blue}"
+    [dev_label]="${KUBE_PS1_ENV_DEV_LABEL:-dev}"
+    [dev_re]="${KUBE_PS1_ENV_DEV_RE:-dev(elop(ment)?)?-}"
+)
+
 _KUBE_PS1_KUBECONFIG_CACHE="${KUBECONFIG}"
 _KUBE_PS1_DISABLE_PATH="${HOME}/.kube/kube-ps1/disabled"
 _KUBE_PS1_LAST_TIME=0
@@ -165,7 +190,7 @@ _kube_ps1_symbol() {
 
   local symbol=""
   local symbol_default=$'\u2388'
-  local symbol_img="☸️" 
+  local symbol_img="☸️"
   local k8s_glyph=$'\Uf10fe'
   local k8s_symbol_color=blue
   local oc_glyph=$'\ue7b7'
@@ -326,6 +351,21 @@ _kube_ps1_get_context_ns() {
   _kube_ps1_get_ns
 }
 
+_kube_ps1_set_env_ctx() {
+  local ctx_color ctx_label
+
+  for ctx in prod test dev stg; do
+    if grep -qE "${KUBE_PS1_ENV[${ctx}_re]}" <<< "${KUBE_PS1_CONTEXT}"; then
+      sed -E "s/${KUBE_PS1_ENV[${ctx}_re]}//g" <<< "${KUBE_PS1_CONTEXT}" > /dev/null
+      ctx_color="$(_kube_ps1_color_fg "${KUBE_PS1_ENV[${ctx}_color]}")"
+      ctx_label="${KUBE_PS1_ENV[${ctx}_label]}"
+    fi
+  done
+
+  KUBE_PS1+="${KUBE_PS1_ENV_PADDING}${KUBE_PS1_ENV_OPEN_SYMBOL}"${ctx_color}${ctx_label}${KUBE_PS1_RESET_COLOR}"${KUBE_PS1_ENV_CLOSE_SYMBOL}${KUBE_PS1_ENV_PADDING}"
+}
+
+
 # Set kube-ps1 shell defaults
 _kube_ps1_init
 
@@ -401,6 +441,11 @@ kube_ps1() {
 
   # Background Color
   [[ -n "${KUBE_PS1_BG_COLOR}" ]] && KUBE_PS1+="$(_kube_ps1_color_bg "${KUBE_PS1_BG_COLOR}")"
+
+  # Context Env
+  if [[ -n "${KUBE_PS1_ENV_CTX_ENABLE}" ]] && [[ "${KUBE_PS1_ENV_CTX_ENABLE}" == true ]]; then
+    _kube_ps1_set_env_ctx
+  fi
 
   # Prefix
   if [[ -z "${KUBE_PS1_PREFIX_COLOR:-}" ]] && [[ -n "${KUBE_PS1_PREFIX}" ]]; then

--- a/kube-ps1.sh
+++ b/kube-ps1.sh
@@ -362,6 +362,8 @@ _kube_ps1_set_env_ctx() {
     fi
   done
 
+  [[ -z "${ctx_label}" ]] && return
+
   KUBE_PS1+="${KUBE_PS1_ENV_PADDING}${KUBE_PS1_ENV_OPEN_SYMBOL}"${ctx_color}${ctx_label}${KUBE_PS1_RESET_COLOR}"${KUBE_PS1_ENV_CLOSE_SYMBOL}${KUBE_PS1_ENV_PADDING}"
 }
 


### PR DESCRIPTION
## Changes:
Add an optional global variable `KUBE_PS1_ENV_CTX_ENABLE` (defaults to `false`) to get environment markers from `KUBE_PS1_CONTEXT` (like dev/test/staging/prod) and display them in a separate block before the main layout; e.g `testing-mycluster` becomes `[test] mycluster`. The main idea for this feature is to be able to manage the colours of your cluster environments independently of cluster names. It also adds many various global variables, so that everyone can tune the feature to their liking and setup.

Here's a demo with 2 different cluster types (postfix and mariadb) but with the same environments:
<img width="500" height="255" alt="kubs-ps1-env" src="https://github.com/user-attachments/assets/8fa9a5ae-be0c-4fc6-8579-7b25c1d63033" />
